### PR TITLE
Install stop-signal handlers in the K8s manager CLI

### DIFF
--- a/pkg/src/alchemiscale_k8s/cli.py
+++ b/pkg/src/alchemiscale_k8s/cli.py
@@ -38,13 +38,23 @@ def manager():
     is_flag=True,
 )
 def manager_start(config_file, service_config_file, steal):
+    from alchemiscale.compute.signals import install_stop_handlers
+
     manager_settings = K8SManagerSettings(**yaml.safe_load(config_file))
 
     service_settings_ = yaml.safe_load(service_config_file)
     service_settings = ComputeServiceSettings(**service_settings_["init"])
 
     manager = K8SManager(manager_settings, service_settings)
-    manager.start(steal=steal)
+
+    # install handlers so SIGHUP/SIGINT/SIGTERM (e.g. K8s pod termination)
+    # stop the manager cleanly
+    install_stop_handlers(manager)
+
+    try:
+        manager.start(steal=steal)
+    except KeyboardInterrupt:
+        pass
 
 
 @manager.command(name="clear-error")


### PR DESCRIPTION
## Summary

The `manager start` command ran `manager.start()` with **no signal handling**. Kubernetes terminates pods with `SIGTERM` (then `SIGKILL` after the grace period), so the manager process was killed without running `ComputeManager.start()`'s `finally` block — orphaning its **`ComputeManagerRegistration`** in the state store on every rollout, scale-down, `kubectl delete pod`, node drain, or eviction. Only an interactive SIGINT cleaned up.

This wires the command to `alchemiscale.compute.signals.install_stop_handlers`, which registers `SIGHUP`/`SIGINT`/`SIGTERM` handlers that call `manager.stop()` (now interruptible, so it wakes the inter-cycle sleep promptly) and let the loop unwind through its deregistration `finally`.

```python
install_stop_handlers(manager)
try:
    manager.start(steal=steal)
except KeyboardInterrupt:
    pass
```

## Notes

- For SIGTERM to actually reach the process, ensure the container runs Python as **PID 1** (or via `exec`/an init like `tini`) so the signal is delivered/forwarded — a `sh -c "..."` entrypoint without `exec` would swallow it.
- The existing `--steal` flag remains a useful safety net for reclaiming a registration left behind by a hard `SIGKILL`.

## Dependency

Requires the `install_stop_handlers` helper (and interruptible-sleep changes) added in the core repo:
**OpenFreeEnergy/alchemiscale#503**. Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)