### PR TITLE
Consolidate compute service init and start settings

### DIFF
--- a/deployment/compute/synchronous-compute-settings.yaml
+++ b/deployment/compute/synchronous-compute-settings.yaml
@@ -1,81 +1,75 @@
 ---
-# options for service initialization
-init:
+# URL of the compute API to execute Tasks for.
+api_url: http://compute.alchemiscale.internal
 
-  # URL of the compute API to execute Tasks for.
-  api_url: http://compute.alchemiscale.internal
+# Identifier for the compute identity used for authentication.
+identifier: compute-identity
 
-  # Identifier for the compute identity used for authentication.
-  identifier: compute-identity
+# Credential for the compute identity used for authentication.
+key: "compute-identity-key"
 
-  # Credential for the compute identity used for authentication.
-  key: "compute-identity-key"
+# The name to give this compute service; used for Task provenance, so
+# typically set to a distinct value to distinguish different compute
+# resources, e.g. different hosts or HPC clusters.
+name: compute-resource-name
 
-  # The name to give this compute service; used for Task provenance, so
-  # typically set to a distinct value to distinguish different compute
-  # resources, e.g. different hosts or HPC clusters.
-  name: compute-resource-name
-  
-  # Filesystem path to use for `ProtocolDAG` `shared` space.
-  shared_basedir: "./shared"
+# Filesystem path to use for `ProtocolDAG` `shared` space.
+shared_basedir: "./shared"
 
-  # Filesystem path to use for `ProtocolUnit` `scratch` space.
-  scratch_basedir: "./scratch"
+# Filesystem path to use for `ProtocolUnit` `scratch` space.
+scratch_basedir: "./scratch"
 
-  # If True, don't remove shared directories for `ProtocolDAG`s after
-  # completion.
-  keep_shared: False
+# If True, don't remove shared directories for `ProtocolDAG`s after
+# completion.
+keep_shared: False
 
-  # If True, don't remove scratch directories for `ProtocolUnit`s after
-  # completion.
-  keep_scratch: False
+# If True, don't remove scratch directories for `ProtocolUnit`s after
+# completion.
+keep_scratch: False
 
-  # Time in seconds to sleep if no Tasks claimed from compute API.
-  sleep_interval: 30
+# Time in seconds to sleep if no Tasks claimed from compute API.
+sleep_interval: 30
 
-  # Frequency at which to send heartbeats to compute API.
-  heartbeat_interval: 300
+# Frequency at which to send heartbeats to compute API.
+heartbeat_interval: 300
 
-  # Scopes to limit Task claiming to; defaults to all Scopes accessible by
-  # compute identity.
-  scopes:
-    - '*-*-*'
+# Scopes to limit Task claiming to; defaults to all Scopes accessible by
+# compute identity.
+scopes:
+  - '*-*-*'
 
-  # Maximum number of Tasks to claim at a time from a TaskHub.
-  claim_limit: 1
+# Maximum number of Tasks to claim at a time from a TaskHub.
+claim_limit: 1
 
-  # The loglevel at which to report via STDOUT; see the :mod:`logging` docs for
-  # available levels.
-  loglevel: 'INFO'
+# Maximum number of Tasks to execute before exiting. If `null`, the service
+# will have no task limit.
+max_tasks: null
 
-  # Path to file for logging output; if not set, logging will only go to
-  # STDOUT.
-  logfile: null
+# Maximum number of seconds to run before exiting. If `null`, the service will
+# have no time limit.
+max_time: null
 
-  # Maximum number of times to retry a request. In the case the API service is
-  # unresponsive an expoenential backoff is applied with retries until this
-  # number is reached. If set to -1, retries will continue indefinitely until
-  # success.
-  client_max_retries: 5
+# The loglevel at which to report via STDOUT; see the :mod:`logging` docs for
+# available levels.
+loglevel: 'INFO'
 
-  # The base number of seconds to use for exponential backoff. Must be greater
-  # than 1.0. 
-  client_retry_base_seconds: 2.0
- 
-  # Maximum number of seconds to sleep between retries; avoids runaway
-  # exponential backoff while allowing for many retries.
-  client_retry_max_seconds: 60.0
+# Path to file for logging output; if not set, logging will only go to
+# STDOUT.
+logfile: null
 
-  # Whether to verify SSL certificate presented by the API server.
-  client_verify: true
+# Maximum number of times to retry a request. In the case the API service is
+# unresponsive an expoenential backoff is applied with retries until this
+# number is reached. If set to -1, retries will continue indefinitely until
+# success.
+client_max_retries: 5
 
-# options for service execution
-start:
+# The base number of seconds to use for exponential backoff. Must be greater
+# than 1.0.
+client_retry_base_seconds: 2.0
 
-  # Max number of Tasks to execute before exiting. If `null`, the service will
-  # have no task limit.
-  max_tasks: null
+# Maximum number of seconds to sleep between retries; avoids runaway
+# exponential backoff while allowing for many retries.
+client_retry_max_seconds: 60.0
 
-  # Max number of seconds to run before exiting. If `null`, the service will
-  # have no time limit.
-  max_time: null
+# Whether to verify SSL certificate presented by the API server.
+client_verify: true

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -118,6 +118,8 @@ key: akey
 shared_basedir: "./shared"
 scratch_basedir: "./scratch"
 claim_limit: 2
+max_tasks: null   # max Tasks to execute before exiting; null = no limit
+max_time: null    # max seconds to run before exiting; null = no limit
 ```
 
 Importantly, the manager uses the `api_url`, `identifier`, and `key` fields for communication with the alchemiscale compute API.

--- a/pkg/src/alchemiscale_k8s/cli.py
+++ b/pkg/src/alchemiscale_k8s/cli.py
@@ -41,7 +41,7 @@ def manager_start(config_file, service_config_file, steal):
     manager_settings = K8SManagerSettings(**yaml.safe_load(config_file))
 
     service_settings_ = yaml.safe_load(service_config_file)
-    service_settings = ComputeServiceSettings(**service_settings_["init"])
+    service_settings = ComputeServiceSettings(**service_settings_)
 
     manager = K8SManager(manager_settings, service_settings)
     manager.start(steal=steal)
@@ -66,7 +66,7 @@ def manager_clear_error(config_file, service_config_file):
     manager_settings = K8SManagerSettings(**yaml.safe_load(config_file))
 
     service_settings_ = yaml.safe_load(service_config_file)
-    service_settings = ComputeServiceSettings(**service_settings_["init"])
+    service_settings = ComputeServiceSettings(**service_settings_)
 
     manager = K8SManager(manager_settings, service_settings)
     manager.clear_error()


### PR DESCRIPTION
## Summary

Companion to **OpenFreeEnergy/alchemiscale#504**, which folds `max_tasks` and `max_time` into `ComputeServiceSettings` and flattens the service-config YAML to a single top-level structure.

## Changes

- `K8SManager` CLI: drop the `service_settings["init"]` key lookup in both `manager start` and `manager clear-error`; configs are now flat.
- `deployment/compute/synchronous-compute-settings.yaml`: flattened; `max_tasks` / `max_time` folded in.
- `pkg/README.md`: note the new lifetime-limit fields in the example.

## Required ordering

This is a **hard cutover** — the matching `alchemiscale` release must land first, otherwise the flattened YAML and the new `ComputeServiceSettings(**service_settings_)` call will mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)